### PR TITLE
mrc-1894 add codecov tokens to environment hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build-kite/vault_config
+.idea

--- a/build-kite/vm_scripts/start-agent.sh
+++ b/build-kite/vm_scripts/start-agent.sh
@@ -43,6 +43,13 @@ $AS_AGENT git config --global push.default simple
 
 echo 'export PATH=/var/lib/buildkite-agent/.local/bin:$PATH' | sudo tee -a /etc/buildkite-agent/hooks/environment
 
+# Add pipeline specific secrets
+if [[ "$BUILDKITE_PIPELINE_SLUG" == "hint" ]]; then
+    CODECOV_TOKEN=$(vault read -field=token secret/hint/codecov)
+fi
+
+echo 'export CODECOV_TOKEN=$CODECOV_TOKEN' | sudo tee -a /etc/buildkite-agent/hooks/environment
+
 TAG_STRING="tags=\"node-type=general,os=ubuntu,vmhost=$VMHOST_NAME\""
 echo $TAG_STRING | sudo tee -a /etc/buildkite-agent/buildkite-agent.cfg
 


### PR DESCRIPTION
It would be nicer if the build agents were permanently logged into vault so we could request things like this as part of pipelines. But for now, this should work.

This is deployed and working.