### PR TITLE
mrc-2036 Pass Codecov token from Vault to Buildkite

### DIFF
--- a/build-kite/vm_scripts/start-agent.sh
+++ b/build-kite/vm_scripts/start-agent.sh
@@ -44,9 +44,11 @@ $AS_AGENT git config --global push.default simple
 # Add pipeline specific secrets to environment
 HINT_CODECOV=$(vault read -field=token secret/hint/codecov)
 MINT_CODECOV=$(vault read -field=token secret/mint/codecov)
+ORDERLYWEB_CODECOV=$(vault read -field=token secret/vimc/orderly-web/codecov)
 cat << EOF > /etc/buildkite-agent/hooks/environment
 HINT_CODECOV=$HINT_CODECOV
 MINT_CODECOV=$MINT_CODECOV
+ORDERLYWEB_CODECOV=$ORDERLYWEB_CODECOV
 EOF
 cat << 'EOF' >> /etc/buildkite-agent/hooks/environment
 export PATH=/var/lib/buildkite-agent/.local/bin:$PATH
@@ -57,6 +59,10 @@ fi
 
 if [[ "$BUILDKITE_PIPELINE_SLUG" == "mint" ]]; then
     CODECOV_TOKEN=$MINT_CODECOV
+fi
+
+if [[ "$BUILDKITE_PIPELINE_SLUG" == "orderly-web" ]]; then
+    CODECOV_TOKEN=$ORDERLYWEB_CODECOV
 fi
 
 export CODECOV_TOKEN=$CODECOV_TOKEN


### PR DESCRIPTION
This adds `ORDERLYWEB_CODECOV` to the Buildkite agent environment alongside the existing `HINT_CODECOV` and `MINT_CODECOV` tokens.

The key has been placed under the existing top-level `vimc` folder in Vault rather than create another top-level folder such as those used by HINT and MINT. But happy to change this - especially if necessary to work with any existing Vault policies that apply to specific paths. Please let me know if this path/token needs to be documented anywhere else.

A corresponding change will be made to OrderlyWeb to use this token as part of the build/test pipeline.