### PR TITLE
Persistent static IP for buildkite agent VMs

### DIFF
--- a/build-kite/vm_scripts/setup-network.sh
+++ b/build-kite/vm_scripts/setup-network.sh
@@ -1,3 +1,15 @@
-sudo ip addr add $IP/24 dev eth0
-sudo ip route add default via $GW dev eth0
-sudo ip link set eth0 up
+sudo cat <<EOF > /etc/netplan/01-netcfg.yaml
+network:
+  version: 2
+  renderer: networkd
+  ethernets:
+    eth0:
+      dhcp4: false
+      dhcp6: false
+      addresses: [$IP/24]
+      gateway4: $GW
+      nameservers:
+        addresses: [8.8.8.8,8.8.4.4]
+EOF
+
+sudo netplan apply


### PR DESCRIPTION
This implements networking with the latest ubuntu preferred methods. Without these, static IP addresses are not persistent, some updates can cause them to be forgotten, and suspending the VM and rewaking it makes them forget the IP too.

This fixes it!