### PR TITLE
mrc-2196 Clean-up any remaining Docker containers after each job

### DIFF
--- a/build-kite/vm_scripts/start-agent.sh
+++ b/build-kite/vm_scripts/start-agent.sh
@@ -68,6 +68,11 @@ fi
 export CODECOV_TOKEN=$CODECOV_TOKEN
 EOF
 
+# Clean-up any remaining Docker containers after each job
+cat <<EOF >>/etc/buildkite-agent/hooks/pre-exit
+docker rm --force $(docker ps --quiet)
+EOF
+
 TAG_STRING="tags=\"node-type=general,os=ubuntu,vmhost=$VMHOST_NAME\""
 echo $TAG_STRING | sudo tee -a /etc/buildkite-agent/buildkite-agent.cfg
 


### PR DESCRIPTION
At the end of each Buildkite build step remove any containers that are still running i.e. that haven't been killed by the job's own clean-up scripts (e.g. OW's [clear-docker.sh](https://github.com/vimc/orderly-web/blob/master/scripts/clear-docker.sh)).

This is performed at the end (i.e. using a [pre-exit](https://buildkite.com/docs/agent/v3/hooks#available-hooks) hook) rather than the beginning because:
- It makes it easier to identify any containers that weren't killed by the job itself (the list appears at the end of the build log)
- With this change there should never be any containers remaining from other jobs that would stop this one commencing

This was tested as follows:
1. `/etc/buildkite-agent/hooks/pre-exit` edited manually on `reside-bk7`
2. `host=reside-bk7` temporarily added to the `tags` setting in `/etc/buildkite-agent/buildkite-agent.cfg` on `reside-bk7`
3. Pushed an [OW branch](https://github.com/vimc/orderly-web/compare/mrc-2196) that targets this host and doesn't clean up its containers
4. Checked via `docker ps` that running containers were killed at the end of each step of [the build](https://buildkite.com/mrc-ide/orderly-web/builds/506#18f43e30-092d-413a-9fce-59b79793765b)

Notes:
- This hook doesn't clean up images, volumes, networks or stopped containers. These should never conflict and are already cleaned-up daily by a cron job (presumably for disk space).
- I haven't made this change in [reside-ic/buildkite-agent](https://github.com/reside-ic/buildkite-agent) - is it still in use?