### PR TITLE
mrc-2211 Fix Buildkite pre-exit hook

### DIFF
--- a/build-kite/vm_scripts/start-agent.sh
+++ b/build-kite/vm_scripts/start-agent.sh
@@ -68,8 +68,8 @@ export CODECOV_TOKEN=$CODECOV_TOKEN
 EOF
 
 # Clean-up any remaining Docker containers after each job
-cat <<EOF >>/etc/buildkite-agent/hooks/pre-exit
-docker rm --force $(docker ps --quiet)
+cat >/etc/buildkite-agent/hooks/pre-exit <<'EOF'
+docker rm --force $(docker ps --quiet) 2>/dev/null || true
 EOF
 
 TAG_STRING="tags=\"node-type=general,os=ubuntu,vmhost=$VMHOST_NAME\""


### PR DESCRIPTION
Quote EOF and ignore error if there are no containers to kill