### PR TITLE
mrc-3099 increase waiting time for cancelled jobs

### DIFF
--- a/build-kite/vm_scripts/start-agent.sh
+++ b/build-kite/vm_scripts/start-agent.sh
@@ -100,5 +100,5 @@ EOF
 chmod +x /etc/cron.daily/docker-cleanup
 
 ## Startup agent
-sudo systemctl enable buildkite-agent && sudo systemctl start buildkite-agent
+sudo systemctl enable buildkite-agent && sudo systemctl start buildkite-agent --cancel-grace-period 60
 


### PR DESCRIPTION
This PR increases cancelled job grace time to a minute. We currently use default cancel time which is 10 seconds. Often times we cancel build kite agent in the middle of job executions, which some times leaves the state staled. 

Increasing the cancel time to a 1 minute gives the build agent sometime for the agent to wait for running jobs docker containers to be cleared rather than leaving debris behind. I understand we have a line clearing the docker when a job fails, but not when cancelled. 