### PR TITLE
Alternative method

### DIFF
--- a/build-kite/vm_scripts/start-agent.sh
+++ b/build-kite/vm_scripts/start-agent.sh
@@ -90,6 +90,7 @@ EOF
 
 TAG_STRING="tags=\"node-type=general,os=ubuntu,vmhost=$VMHOST_NAME,queue=$1\""
 echo $TAG_STRING | sudo tee -a /etc/buildkite-agent/buildkite-agent.cfg
+echo "cancel-grace-period=60" | sudo tee -a /etc/buildkite-agent/buildkite-agent.cfg
 
 cat <<EOF > /etc/cron.daily/docker-cleanup
 #!/usr/bin/env bash
@@ -100,5 +101,4 @@ EOF
 chmod +x /etc/cron.daily/docker-cleanup
 
 ## Startup agent
-sudo systemctl enable buildkite-agent && sudo systemctl start buildkite-agent --cancel-grace-period 60
-
+sudo systemctl enable buildkite-agent && sudo systemctl start buildkite-agent


### PR DESCRIPTION
Unfortunately, in the first version --cancel-grace-period=60 gets passed to systemctl, and not to the buildkite-agent startup. 

According to 
https://buildkite.com/docs/agent/v3/configuration 

cancel-grace-period=60

can be included in the config file for the same effect - in our case /etc/buildkite-agent/buildkite-agent.cfg - and since we already do this with some other lines, I've added another one that hopefully does the trick.