### PR TITLE
Turn off password login by default

### DIFF
--- a/bots/Vagrantfile
+++ b/bots/Vagrantfile
@@ -19,13 +19,16 @@ Vagrant.configure(2) do |config|
     hyperv.auto_stop_action = "Save"
   end
   config.vm.hostname = hostname
-  
+
   config.vm.provision :shell, path: "../common/setup.sh",
 		                                  env: {"hostname" => hostname}
-  
+
   config.vm.provision :shell, path: "./vm_scripts/setup-user.sh",
                                           env: {"newuser" => "wes", "machine" => "wrh1@wpia-dide065", "pubkey" => "AAAAB3NzaC1yc2EAAAABJQAAAQEAgR9Atls6I2HHHlk5GdsCZO9oXiysVmFtxWr0pOg0B145W4VrkbJbysxvpqGbv+V4A0WFOLMnFaGOSntrBGBpjZ9IudKkpPQgtXoh4kSVflRW5Rq26nj9CnfpQdHWAzX6XCA5fJtfGegHkSMzghO0SQ+/6qboE3KkYAbEUfYAkxhMgD2zU2GKvLfEb6UPKBYpxMjc5J39/pn1laRUTS7nyj98CzOGQhU2hB1PYq9S77hWGmlJsREwgfs8a3aWEEKSbvUR8x1JtD/OE69nwbaY0gd79JJ2sF2mFZoYdmsNHpFndKKMMqwWL4sLihGke0f0Xss8vCuLDWvng4k4cKQ5hw=="}
-             
+
   config.vm.provision :shell, path: "../common/setup-docker.sh"
-  
+
+  config.vm.provision :shell, path: "../common/setup-ssh-keys.sh", run: "always",
+                              args: ["r-ash", "richfitz", "weshinsley", "hillalex", "EmmaLRussell"]
+
 end

--- a/comet/Vagrantfile
+++ b/comet/Vagrantfile
@@ -22,5 +22,6 @@ Vagrant.configure(2) do |config|
   config.vm.provision :shell, path: "../common/setup.sh",
 		                                  env: {"hostname" => hostname}
   config.vm.provision :shell, path: "../common/setup-docker.sh"
-  
+  config.vm.provision :shell, path: "../common/setup-ssh-keys.sh", run: "always",
+                              args: ["richfitz", "weshinsley", "hillalex", "EmmaLRussell"]
 end

--- a/common/setup-ssh-keys.sh
+++ b/common/setup-ssh-keys.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -ex
+
+if ! which -a curl > /dev/null; then
+    echo "installing curl"
+    apt-get -y update && apt-get -y upgrade
+    apt-get -y install curl
+fi
+
+for username in "$@"
+do
+    curl --no-progress-meter https://github.com/$username.keys >> "/home/vagrant/.ssh/authorized_keys"
+done

--- a/common/setup.sh
+++ b/common/setup.sh
@@ -42,5 +42,5 @@ chmod 755 /etc/cron.daily/check_reboot_required
 
 # Only allow login with keys
 
-# sed -i 's|#PasswordAuthentication yes|PasswordAuthentication no|' /etc/ssh/sshd_config
-# sed -i 's|#PubkeyAuthentication yes|PubkeyAuthentication yes|' /etc/ssh/sshd_config
+sed -i 's|#PasswordAuthentication yes|PasswordAuthentication no|' /etc/ssh/sshd_config
+sed -i 's|#PubkeyAuthentication yes|PubkeyAuthentication yes|' /etc/ssh/sshd_config

--- a/covid19-forecasts/Vagrantfile
+++ b/covid19-forecasts/Vagrantfile
@@ -22,5 +22,6 @@ Vagrant.configure(2) do |config|
   config.vm.provision :shell, path: "../common/setup.sh",
 		                                  env: {"hostname" => hostname}
   config.vm.provision :shell, path: "../common/setup-docker.sh"
-  
+  config.vm.provision :shell, path: "../common/setup-ssh-keys.sh", run: "always",
+                              args: ["richfitz", "weshinsley"]
 end

--- a/db-experiment/Vagrantfile
+++ b/db-experiment/Vagrantfile
@@ -25,4 +25,6 @@ Vagrant.configure(2) do |config|
 
   config.vm.provision :shell, path: "../common/setup-docker.sh"
 
+  config.vm.provision :shell, path: "../common/setup-ssh-keys.sh", run: "always",
+                              args: ["r-ash", "richfitz", "weshinsley", "hillalex", "EmmaLRussell"]
 end

--- a/mint-dev/Vagrantfile
+++ b/mint-dev/Vagrantfile
@@ -19,10 +19,11 @@ Vagrant.configure(2) do |config|
     hyperv.auto_stop_action = "Save"
   end
   config.vm.hostname = hostname
-  
+
   config.vm.provision :shell, path: "../common/setup.sh",
 		                                  env: {"hostname" => hostname}
-  
+
   config.vm.provision :shell, path: "../common/setup-docker.sh"
-  
+  config.vm.provision :shell, path: "../common/setup-ssh-keys.sh", run: "always",
+                              args: ["richfitz", "weshinsley", "hillalex", "EmmaLRussell"]
 end

--- a/ncov-dev/Vagrantfile
+++ b/ncov-dev/Vagrantfile
@@ -22,5 +22,6 @@ Vagrant.configure(2) do |config|
   config.vm.provision :shell, path: "../common/setup.sh",
 		                                  env: {"hostname" => hostname}
   config.vm.provision :shell, path: "../common/setup-docker.sh"
-  
+  config.vm.provision :shell, path: "../common/setup-ssh-keys.sh", run: "always",
+                              args: ["richfitz", "weshinsley"]
 end


### PR DESCRIPTION
We want to turn off password login for db-experiment VM. I've done this change manually for the time being, but we probably want to do this for all VMs by default.

The VMs which use this script are
* db-experiment
* ncov-dev
* comet
* covid19-forecasts
* mint-dev
* bots

Are there any of these we want to keep password login on?