### PR TITLE
Update curl flags to work with older versions

### DIFF
--- a/common/setup-ssh-keys.sh
+++ b/common/setup-ssh-keys.sh
@@ -9,5 +9,5 @@ fi
 
 for username in "$@"
 do
-    curl --no-progress-meter https://github.com/$username.keys >> "/home/vagrant/.ssh/authorized_keys"
+    curl -sS https://github.com/$username.keys >> "/home/vagrant/.ssh/authorized_keys"
 done


### PR DESCRIPTION
When porting to hiv-hyperv-scripts I checked this was working but looks like the default version of curl installed on ubuntu 18.04 does not have the `--no-progress-meter` arg available. `-sS` should give similar effect, silent but show any errors. 