### PR TITLE
Update buildkite agents to ubuntu 22

### DIFF
--- a/build-kite/Vagrantfile
+++ b/build-kite/Vagrantfile
@@ -7,7 +7,7 @@ vault_config = Hash[File.read(vault_config_file).split("\n").
 Vagrant.require_version ">= 2.2.10"
 
 domain = 'localdomain'
-box = "generic/ubuntu1804"
+box = "generic/ubuntu2204"
 gateway = "14.0.0.1"
 ram = "16384"
 agents = [


### PR DESCRIPTION
I have restarted reside-bk8 so that is currently on ubuntu 22 and looks to be working ok.

It has successfully run a build which failed previously due to python issues https://buildkite.com/mrc-ide/montagu-db/builds/72#0183ebf1-c84d-41a8-a491-ded9e7a397b3 Though not clear if this is going to fix that generally