### PR TITLE
Add setup for running multicore agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,14 +65,17 @@ local, with `14.0.0.1` as the gateway, or a DIDE assigned IP address. Those exis
 | reside-bk8             |   1   | 16  | 100  |  27 | 14.0.0.9 |
 | reside-deploy1         |   1   | 16  | 100  |  28 | 14.0.0.10|
 | reside-bk-browser-test1|   4   | 64  | 100  |  29 | 14.0.0.11|
+ | reside-bk-multicore1   |   4   | 64  | 100  |  30 | 14.0.0.12|
+ | reside-bk-multicore2   |   4   | 64  | 100  |  30 | 14.0.0.12|
+ | reside-bk-multicore3   |   4   | 64  | 100  |  30 | 14.0.0.12|
 
 ## Usage of whole machine:
 
-|                      | Total     | VM allocated   |   Spare   |
-|----------------------|-----------|----------------|-----------|
-| Cores (logical)      |    96     |     61         |    35     |
-| RAM (Gb)             |  1024     |    690         |   334     |
-| DISK (D: SSD) (Tb)   |  11.6     |    7.3         |   4.3     |
+|                      | Total     | VM allocated | Spare |
+|----------------------|-----------|--------------|-------|
+| Cores (logical)      |    96     | 73           | 23    |
+| RAM (Gb)             |  1024     | 786          | 238   |
+| DISK (D: SSD) (Tb)   |  11.6     | 7.6          | 4.0   |
 
 ## Retired VMs
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ local, with `14.0.0.1` as the gateway, or a DIDE assigned IP address. Those exis
 | reside-deploy1         |   1   | 16  | 100  |  28 | 14.0.0.10|
 | reside-bk-browser-test1|   4   | 64  | 100  |  29 | 14.0.0.11|
  | reside-bk-multicore1   |   4   | 64  | 100  |  30 | 14.0.0.12|
- | reside-bk-multicore2   |   4   | 64  | 100  |  30 | 14.0.0.12|
+ | reside-bk-multicore2   |   4   | 64  | 100  |  30 | 14.0.0.13|
  | reside-bk-multicore3   |   4   | 64  | 100  |  30 | 14.0.0.14|
 
 ## Usage of whole machine:

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ local, with `14.0.0.1` as the gateway, or a DIDE assigned IP address. Those exis
 | reside-bk-browser-test1|   4   | 64  | 100  |  29 | 14.0.0.11|
  | reside-bk-multicore1   |   4   | 64  | 100  |  30 | 14.0.0.12|
  | reside-bk-multicore2   |   4   | 64  | 100  |  30 | 14.0.0.12|
- | reside-bk-multicore3   |   4   | 64  | 100  |  30 | 14.0.0.12|
+ | reside-bk-multicore3   |   4   | 64  | 100  |  30 | 14.0.0.14|
 
 ## Usage of whole machine:
 

--- a/build-kite/Vagrantfile
+++ b/build-kite/Vagrantfile
@@ -20,6 +20,12 @@ agents = [
   { :hostname => 'reside-bk7', :ip => '14.0.0.8', :mac => "00:15:5d:1a:84:26", :queue => "default"},
   { :hostname => 'reside-bk8', :ip => '14.0.0.9', :mac => "00:15:5d:1a:84:27", :queue => "default"},
   { :hostname => 'reside-deploy1', :ip => '14.0.0.10', :mac => "00:15:5d:1a:84:28", :queue => "hint-deploy"}
+  { :hostname => 'reside-bk-multicore1', :ip => '14.0.0.12', :mac => "00:15:5d:1a:84:30", :queue => "parallel",
+    :cpus => 4, :ram => '65536'}
+  { :hostname => 'reside-bk-multicore2', :ip => '14.0.0.13', :mac => "00:15:5d:1a:84:31", :queue => "parallel",
+    :cpus => 4, :ram => '65536'}
+  { :hostname => 'reside-bk-multicore3', :ip => '14.0.0.14', :mac => "00:15:5d:1a:84:32", :queue => "parallel",
+    :cpus => 4, :ram => '65536'}
 ]
 
 Vagrant.configure(2) do |config|
@@ -31,9 +37,9 @@ Vagrant.configure(2) do |config|
       agent_config.vm.provider :hyperv do |hyperv|
         hyperv.mac = agent[:mac]
         hyperv.vmname = agent[:hostname]
-        hyperv.cpus = 1
-        hyperv.maxmemory = ram
-        hyperv.memory = ram
+        hyperv.cpus = agent[:cpus] || 1
+        hyperv.maxmemory = agent[:ram] || ram
+        hyperv.memory = agent[:ram] || ram
         hyperv.auto_start_action = "StartIfRunning"
         hyperv.auto_stop_action = "Save"
       end

--- a/build-kite/Vagrantfile
+++ b/build-kite/Vagrantfile
@@ -19,11 +19,11 @@ agents = [
   { :hostname => 'reside-bk6', :ip => '14.0.0.7', :mac => "00:15:5d:1a:84:25", :queue => "default"},
   { :hostname => 'reside-bk7', :ip => '14.0.0.8', :mac => "00:15:5d:1a:84:26", :queue => "default"},
   { :hostname => 'reside-bk8', :ip => '14.0.0.9', :mac => "00:15:5d:1a:84:27", :queue => "default"},
-  { :hostname => 'reside-deploy1', :ip => '14.0.0.10', :mac => "00:15:5d:1a:84:28", :queue => "hint-deploy"}
+  { :hostname => 'reside-deploy1', :ip => '14.0.0.10', :mac => "00:15:5d:1a:84:28", :queue => "hint-deploy"},
   { :hostname => 'reside-bk-multicore1', :ip => '14.0.0.12', :mac => "00:15:5d:1a:84:30", :queue => "parallel",
-    :cpus => 4, :ram => '65536'}
+    :cpus => 4, :ram => '65536'},
   { :hostname => 'reside-bk-multicore2', :ip => '14.0.0.13', :mac => "00:15:5d:1a:84:31", :queue => "parallel",
-    :cpus => 4, :ram => '65536'}
+    :cpus => 4, :ram => '65536'},
   { :hostname => 'reside-bk-multicore3', :ip => '14.0.0.14', :mac => "00:15:5d:1a:84:32", :queue => "parallel",
     :cpus => 4, :ram => '65536'}
 ]


### PR DESCRIPTION
This is so we can run hintr and naomi tests in parallel, thinking here is
* 3 agents so we can run a build simultaneously (1 hintr tests, 1 hintr code cov, 1 naomi tests)
* Have gone for 4 core 64GB machines as we have the resources available for it but can always reduce these if we need more cores for something else in the future

I've run these up and checked they are working 