### PR TITLE
Give multicore buildkite agents more memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,16 +43,16 @@ local, with `14.0.0.1` as the gateway, or a DIDE assigned IP address. Those exis
 
 | Machine                | Cores | RAM | Disk | MAC |     IP   |
 |------------------------|-------|-----|------|-----|----------|
-| wpia-vault             |   1   |  4  |  50  |  01 |   dide   |
+| wpia-vault             |   1   | 4   |  50  |  01 |   dide   |
 | wpia-mint              |   2   | 16  | 500  |  02 |   dide   |
 | wpia-data              |   2   | 16  | 100  |  03 |   dide   |
-| wpia-bots              |   1   |  2  | 100  |  05 |   dide   |
+| wpia-bots              |   1   | 2   | 100  |  05 |   dide   |
 | wpia-mint-dev          |   2   | 16  | 500  |  06 |   dide   |
 | wpia-ncov-dev          |   10  | 64  | 1000 |  07 |   dide   |
 | wpia-covid19-forecasts |   6   | 32  | 1000 |  08 |   dide   |
-| wpia-comet             |   2   |  8  | 100  |  09 |   dide   |
-| wpia-db-experiment     |   2   | 256 | 2000 |  10 |   dide   |
-| wpia-wodin-dev         |   2   |  4  | 200  |  12 |   dide   |
+| wpia-comet             |   2   | 8   | 100  |  09 |   dide   |
+| wpia-db-experiment     |   2   | 128 | 2000 |  10 |   dide   |
+| wpia-wodin-dev         |   2   | 4   | 200  |  12 |   dide   |
 | wpia-epimodels         |   12  | 64  | 200  |  13 |   dide   |
 | wpia-beebop            |   10  | 64  | 500  |  14 |   dide   |
 | reside-bk1             |   1   | 16  | 100  |  20 | 14.0.0.2 |
@@ -65,16 +65,16 @@ local, with `14.0.0.1` as the gateway, or a DIDE assigned IP address. Those exis
 | reside-bk8             |   1   | 16  | 100  |  27 | 14.0.0.9 |
 | reside-deploy1         |   1   | 16  | 100  |  28 | 14.0.0.10|
 | reside-bk-browser-test1|   4   | 64  | 100  |  29 | 14.0.0.11|
- | reside-bk-multicore1   |   4   | 64  | 100  |  30 | 14.0.0.12|
- | reside-bk-multicore2   |   4   | 64  | 100  |  30 | 14.0.0.13|
- | reside-bk-multicore3   |   4   | 64  | 100  |  30 | 14.0.0.14|
+ | reside-bk-multicore1   |   4   | 128 | 100  |  30 | 14.0.0.12|
+ | reside-bk-multicore2   |   4   | 128 | 100  |  30 | 14.0.0.13|
+ | reside-bk-multicore3   |   4   | 128 | 100  |  30 | 14.0.0.14|
 
 ## Usage of whole machine:
 
 |                      | Total     | VM allocated | Spare |
 |----------------------|-----------|--------------|-------|
 | Cores (logical)      |    96     | 73           | 23    |
-| RAM (Gb)             |  1024     | 786          | 238   |
+| RAM (Gb)             |  1024     | 850          | 174   |
 | DISK (D: SSD) (Tb)   |  11.6     | 7.6          | 4.0   |
 
 ## Retired VMs

--- a/build-kite/Vagrantfile
+++ b/build-kite/Vagrantfile
@@ -21,11 +21,11 @@ agents = [
   { :hostname => 'reside-bk8', :ip => '14.0.0.9', :mac => "00:15:5d:1a:84:27", :queue => "default"},
   { :hostname => 'reside-deploy1', :ip => '14.0.0.10', :mac => "00:15:5d:1a:84:28", :queue => "hint-deploy"},
   { :hostname => 'reside-bk-multicore1', :ip => '14.0.0.12', :mac => "00:15:5d:1a:84:30", :queue => "parallel",
-    :cpus => 4, :ram => '65536'},
+    :cpus => 4, :ram => '131072'},
   { :hostname => 'reside-bk-multicore2', :ip => '14.0.0.13', :mac => "00:15:5d:1a:84:31", :queue => "parallel",
-    :cpus => 4, :ram => '65536'},
+    :cpus => 4, :ram => '131072'},
   { :hostname => 'reside-bk-multicore3', :ip => '14.0.0.14', :mac => "00:15:5d:1a:84:32", :queue => "parallel",
-    :cpus => 4, :ram => '65536'}
+    :cpus => 4, :ram => '131072'}
 ]
 
 Vagrant.configure(2) do |config|

--- a/db-experiment/Vagrantfile
+++ b/db-experiment/Vagrantfile
@@ -1,7 +1,7 @@
 # -*- mode: ruby -*-
 
 box = "generic/ubuntu1804"
-ram = "262144"
+ram = "131072"
 hostname = "wpia-db-experiment"
 mac = "00:15:5d:1a:84:10"
 cpus = 2


### PR DESCRIPTION
I've tested builds running on 4 core 64 GB machines with 2 processes https://buildkite.com/mrc-ide/hintr/builds/1985#0185977c-5e03-447f-8095-a9b772483ca1/244-258
and with 4 processes https://buildkite.com/mrc-ide/hintr/builds/1987#0185979a-51bc-475a-a6f8-fd9d0ec60c19/215-229

You can see in 4 process job each individual file took longer to run than on the 2 processes build, I am guessing this is because it is memory limited. I've moved some memory about to try and check/confirm this. This takes 128GB from the experiment DB - I don't think we should need to do anything too intensive on that now as the prototyping has finished and we are back to using annex for storing stochastic data.