### PR TITLE
Add env var for number of cores on multicore buildkite agents and reduce their memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,31 +43,31 @@ local, with `14.0.0.1` as the gateway, or a DIDE assigned IP address. Those exis
 
 | Machine                | Cores | RAM | Disk | MAC |     IP   |
 |------------------------|-------|-----|------|-----|----------|
-| wpia-vault             |   1   | 4   |  50  |  01 |   dide   |
-| wpia-mint              |   2   | 16  | 500  |  02 |   dide   |
-| wpia-data              |   2   | 16  | 100  |  03 |   dide   |
-| wpia-bots              |   1   | 2   | 100  |  05 |   dide   |
-| wpia-mint-dev          |   2   | 16  | 500  |  06 |   dide   |
-| wpia-ncov-dev          |   10  | 64  | 1000 |  07 |   dide   |
-| wpia-covid19-forecasts |   6   | 32  | 1000 |  08 |   dide   |
-| wpia-comet             |   2   | 8   | 100  |  09 |   dide   |
-| wpia-db-experiment     |   2   | 128 | 2000 |  10 |   dide   |
-| wpia-wodin-dev         |   2   | 4   | 200  |  12 |   dide   |
-| wpia-epimodels         |   12  | 64  | 200  |  13 |   dide   |
-| wpia-beebop            |   10  | 64  | 500  |  14 |   dide   |
-| reside-bk1             |   1   | 16  | 100  |  20 | 14.0.0.2 |
-| reside-bk2             |   1   | 16  | 100  |  21 | 14.0.0.3 |
-| reside-bk3             |   1   | 16  | 100  |  22 | 14.0.0.4 |
-| reside-bk4             |   1   | 16  | 100  |  23 | 14.0.0.5 |
-| reside-bk5             |   1   | 16  | 100  |  24 | 14.0.0.6 |
-| reside-bk6             |   1   | 16  | 100  |  25 | 14.0.0.7 |
-| reside-bk7             |   1   | 16  | 100  |  26 | 14.0.0.8 |
-| reside-bk8             |   1   | 16  | 100  |  27 | 14.0.0.9 |
-| reside-deploy1         |   1   | 16  | 100  |  28 | 14.0.0.10|
-| reside-bk-browser-test1|   4   | 64  | 100  |  29 | 14.0.0.11|
- | reside-bk-multicore1   |   4   | 128 | 100  |  30 | 14.0.0.12|
- | reside-bk-multicore2   |   4   | 128 | 100  |  30 | 14.0.0.13|
- | reside-bk-multicore3   |   4   | 128 | 100  |  30 | 14.0.0.14|
+| wpia-vault             |   1   | 4   |  50  | 01  |   dide   |
+| wpia-mint              |   2   | 16  | 500  | 02  |   dide   |
+| wpia-data              |   2   | 2   | 100  | 03  |   dide   |
+| wpia-bots              |   1   | 2   | 100  | 05  |   dide   |
+| wpia-mint-dev          |   2   | 16  | 500  | 06  |   dide   |
+| wpia-ncov-dev          |   10  | 64  | 1000 | 07  |   dide   |
+| wpia-covid19-forecasts |   6   | 32  | 1000 | 08  |   dide   |
+| wpia-comet             |   2   | 8   | 100  | 09  |   dide   |
+| wpia-db-experiment     |   2   | 128 | 2000 | 10  |   dide   |
+| wpia-wodin-dev         |   2   | 4   | 200  | 12  |   dide   |
+| wpia-epimodels         |   12  | 64  | 200  | 13  |   dide   |
+| wpia-beebop            |   10  | 64  | 500  | 14  |   dide   |
+| reside-bk1             |   1   | 16  | 100  | 20  | 14.0.0.2 |
+| reside-bk2             |   1   | 16  | 100  | 21  | 14.0.0.3 |
+| reside-bk3             |   1   | 16  | 100  | 22  | 14.0.0.4 |
+| reside-bk4             |   1   | 16  | 100  | 23  | 14.0.0.5 |
+| reside-bk5             |   1   | 16  | 100  | 24  | 14.0.0.6 |
+| reside-bk6             |   1   | 16  | 100  | 25  | 14.0.0.7 |
+| reside-bk7             |   1   | 16  | 100  | 26  | 14.0.0.8 |
+| reside-bk8             |   1   | 16  | 100  | 27  | 14.0.0.9 |
+| reside-deploy1         |   1   | 1   | 100  | 28  | 14.0.0.10|
+| reside-bk-browser-test1|   4   | 64  | 100  | 29  | 14.0.0.11|
+ | reside-bk-multicore1   |   4   | 64  | 100  | 30  | 14.0.0.12|
+ | reside-bk-multicore2   |   4   | 64  | 100  | 31  | 14.0.0.13|
+ | reside-bk-multicore3   |   4   | 64  | 100  | 32  | 14.0.0.14|
 
 ## Usage of whole machine:
 

--- a/build-kite/Vagrantfile
+++ b/build-kite/Vagrantfile
@@ -19,13 +19,14 @@ agents = [
   { :hostname => 'reside-bk6', :ip => '14.0.0.7', :mac => "00:15:5d:1a:84:25", :queue => "default"},
   { :hostname => 'reside-bk7', :ip => '14.0.0.8', :mac => "00:15:5d:1a:84:26", :queue => "default"},
   { :hostname => 'reside-bk8', :ip => '14.0.0.9', :mac => "00:15:5d:1a:84:27", :queue => "default"},
-  { :hostname => 'reside-deploy1', :ip => '14.0.0.10', :mac => "00:15:5d:1a:84:28", :queue => "hint-deploy"},
+  { :hostname => 'reside-deploy1', :ip => '14.0.0.10', :mac => "00:15:5d:1a:84:28", :queue => "hint-deploy",
+    :ram = '1024'},
   { :hostname => 'reside-bk-multicore1', :ip => '14.0.0.12', :mac => "00:15:5d:1a:84:30", :queue => "parallel",
-    :cpus => 4, :ram => '131072'},
+    :cpus => 4, :ram => '65536'},
   { :hostname => 'reside-bk-multicore2', :ip => '14.0.0.13', :mac => "00:15:5d:1a:84:31", :queue => "parallel",
-    :cpus => 4, :ram => '131072'},
+    :cpus => 4, :ram => '65536'},
   { :hostname => 'reside-bk-multicore3', :ip => '14.0.0.14', :mac => "00:15:5d:1a:84:32", :queue => "parallel",
-    :cpus => 4, :ram => '131072'}
+    :cpus => 4, :ram => '65536'}
 ]
 
 Vagrant.configure(2) do |config|

--- a/build-kite/vm_scripts/start-agent.sh
+++ b/build-kite/vm_scripts/start-agent.sh
@@ -83,6 +83,13 @@ fi
 export CODECOV_TOKEN=$CODECOV_TOKEN
 EOF
 
+# Add no of cores as env var, used for controlling num processes
+# when running tests in parallel
+NUM_CORES=$(grep -c ^processor /proc/cpuinfo)
+cat << EOF > /etc/buildkite-agent/hooks/environment
+NUM_CORES=$NUM_CORES
+EOF
+
 # Clean-up any remaining Docker containers after each job
 cat >/etc/buildkite-agent/hooks/pre-exit <<'EOF'
 docker rm --force $(docker ps --quiet) 2>/dev/null || true


### PR DESCRIPTION
This PR will
* Reduce memory on multicore agents (I increased this temporarily to test whether it would make parallel tests run faster - it doesn't these are not memory bound)
* Add env var on buildkite agents so we can control how many parallel threads testthat will spawn

Still todo here is update the VM allocated and spare memory 
Question for @weshinsley the totals for vault, data, mint and mint-dev don't match what is in the table here, and indeed the values seem a bit arbitrary? Is this some dynamic memory resizing thing?