### PR TITLE
Update agent setup script to use latest pgp key

### DIFF
--- a/build-kite/vm_scripts/setup-agent.sh
+++ b/build-kite/vm_scripts/setup-agent.sh
@@ -2,8 +2,8 @@
 set -e
 
 ## Setup as an agent
-echo "deb https://apt.buildkite.com/buildkite-agent stable main" | sudo tee /etc/apt/sources.list.d/buildkite-agent.list
-sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198
+curl -fsSL https://keys.openpgp.org/vks/v1/by-fingerprint/32A37959C2FA5C3C99EFBC32A79206696452D198 | sudo gpg --dearmor -o /usr/share/keyrings/buildkite-agent-archive-keyring.gpg
+echo "deb [signed-by=/usr/share/keyrings/buildkite-agent-archive-keyring.gpg] https://apt.buildkite.com/buildkite-agent stable main" | sudo tee /etc/apt/sources.list.d/buildkite-agent.list
 sudo apt-get update && sudo apt-get install -y buildkite-agent
 
 # Enable passwordless login


### PR DESCRIPTION
We're getting some weird docker network problems on hint builds. Just want to tear everything down and bring it back up to ensure we're on latest version of everything as a first step. I've updated the buildkite installation steps here to follow their latest instructions too